### PR TITLE
Typo in object name

### DIFF
--- a/lib/github_cli/cli.rb
+++ b/lib/github_cli/cli.rb
@@ -11,7 +11,7 @@ module GithubCLI
       super
       the_shell = (options["no-color"] ? Thor::Shell::Basic.new : shell)
       GithubCLI.ui = UI.new(the_shell)
-      GithubCLi.ui.debug! if options["verbose"]
+      GithubCLI.ui.debug! if options["verbose"]
       options["no-pager"] ? Pager.disable : Pager.enable
     end
 


### PR DESCRIPTION
I was trying to use --verbose to get more information, and got an error caused by this.
However, I can't work out how to e.g. list issues for a particular repository, gcli issues list --help doesn't work, and trying --org/--repo parameters doesn't seem to either.
