### PR TITLE
[WIP] Update json gem.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       oauth2
     hashie (3.4.4)
     hpricot (0.8.6)
-    json (1.8.0)
+    json (1.8.3)
     jwt (1.5.1)
     mini_portile2 (2.0.0)
     multi_json (1.12.1)


### PR DESCRIPTION
I was using the Ruby 2.3.1, and tried to `bundle install`, met with json extension compilation issues, and find that is not the older json is not compatible with latest version, so I `bundle update json`.

Ref: http://stackoverflow.com/questions/29578142/how-to-install-json-gem-failed-to-build-gem-native-extensionmac-10-10

Attached failure log:

```bash
Installing json 1.8.0 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/BX/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/json-1.8.0/ext/json/ext/generator
/Users/BX/.rbenv/versions/2.3.1/bin/ruby -r ./siteconf20160604-30772-1jcbopc.rb extconf.rb
creating Makefile

current directory: /Users/BX/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/json-1.8.0/ext/json/ext/generator
make "DESTDIR=" clean

current directory: /Users/BX/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/json-1.8.0/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
In file included from generator.c:1:
./../fbuffer/fbuffer.h:175:47: error: too few arguments provided to function-like macro invocation
    VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                              ^
/Users/BX/.rbenv/versions/2.3.1/include/ruby-2.3.0/ruby/intern.h:797:9: note: macro 'rb_str_new' defined here
#define rb_str_new(str, len) __extension__ (    \
        ^
In file included from generator.c:1:
./../fbuffer/fbuffer.h:175:11: warning: incompatible pointer to integer conversion initializing 'VALUE' (aka 'unsigned long') with an expression of type 'VALUE (const char *, long)' (aka 'unsigned long (const char *, long)') [-Wint-conversion]
    VALUE result = rb_str_new(FBUFFER_PAIR(fb));
          ^        ~~~~~~~~~~
1 warning and 1 error generated.
make: *** [generator.o] Error 1

make failed, exit code 2

```

